### PR TITLE
add support for recent versions of Google Chrome

### DIFF
--- a/check/index.html
+++ b/check/index.html
@@ -1,7 +1,7 @@
 <html>
   <body>
   <script>
-    document.cookie = 's=1';
+    document.cookie = 's=1; SameSite=None; Secure';
     document.location = 'read-cookie.html';
   </script>
   </body>


### PR DESCRIPTION
Some time ago, Google Chrome changed its policy for cross-site cookie reading as you can see [here](https://developers.google.com/search/blog/2020/01/get-ready-for-new-samesitenone-secure#chrome-enforcement-starting-in-february-2020). So now we need to add the `SameSite=None; Secure` to make this lib work properly on Google Chrome. I hope it is helpful.